### PR TITLE
Use different library names for Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if( NOT BUILD_WITH_QT4 )
 endif()
 
 if(Qt5Core_DIR)
+    set(LASTFM_LIB_VERSION_SUFFIX 5)
     message(STATUS "Found Qt5! Please keep in mind, this is highly experimental and not our main development target..")
     include_directories(${Qt5Core_INCLUDE_DIRS})
 
@@ -68,6 +69,12 @@ endif()
 if(MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:wchar_t-")
 endif(MSVC)
+
+set(LASTFM_LIB_TARGET_NAME lastfm${LASTFM_LIB_VERSION_SUFFIX} CACHE
+    INTERNAL "Target name of liblastfm" FORCE)
+
+set(FINGERPRINT_LIB_TARGET_NAME lastfm_fingerprint${LASTFM_LIB_VERSION_SUFFIX} CACHE
+    INTERNAL "Target name of liblastfm_fingerprint" FORCE)
 
 # main library
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,17 +87,17 @@ if(UNIX AND NOT APPLE)
     list(APPEND liblastfm_QT5_MODULES DBus)
 endif()
 
-add_library(lastfm SHARED ${liblastfm_SOURCES})
-qt5_use_modules(lastfm ${liblastfm_QT5_MODULES})
+add_library(${LASTFM_LIB_TARGET_NAME} SHARED ${liblastfm_SOURCES})
+qt5_use_modules(${LASTFM_LIB_TARGET_NAME} ${liblastfm_QT5_MODULES})
 
-target_link_libraries(lastfm ${liblastfm_LIBRARIES})
-set_target_properties(lastfm PROPERTIES
+target_link_libraries(${LASTFM_LIB_TARGET_NAME} ${liblastfm_LIBRARIES})
+set_target_properties(${LASTFM_LIB_TARGET_NAME} PROPERTIES
     VERSION ${LASTFM_VERSION_STRING}
     SOVERSION ${LASTFM_SOVERSION}
     COMPILE_DEFINITIONS LASTFM_LIB
 )
 
-install(TARGETS lastfm
+install(TARGETS ${LASTFM_LIB_TARGET_NAME}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/fingerprint/CMakeLists.txt
+++ b/src/fingerprint/CMakeLists.txt
@@ -24,25 +24,25 @@ set(lastfm_fingerprint_HEADERS
     FingerprintableSource.h
 )
 
-add_library(lastfm_fingerprint SHARED ${lastfm_fingerprint_SOURCES})
+add_library(${FINGERPRINT_LIB_TARGET_NAME} SHARED ${lastfm_fingerprint_SOURCES})
 
-target_link_libraries(lastfm_fingerprint
-    lastfm
+target_link_libraries(${FINGERPRINT_LIB_TARGET_NAME}
+    ${LASTFM_LIB_TARGET_NAME}
     ${QT_QTSQL_LIBRARY}
     ${QT_QTCORE_LIBRARY}
     ${LIBSAMPLERATE_LIBRARY}
     ${LIBFFTW3_LIBRARY}
 )
 
-set_target_properties(lastfm_fingerprint PROPERTIES
+set_target_properties(${FINGERPRINT_LIB_TARGET_NAME} PROPERTIES
     COMPILE_DEFINITIONS LASTFM_FINGERPRINT_LIB
     VERSION ${LASTFM_VERSION_STRING}
     SOVERSION ${LASTFM_SOVERSION}
 )
 
-qt5_use_modules(lastfm_fingerprint Network Sql Xml)
+qt5_use_modules(${FINGERPRINT_LIB_TARGET_NAME} Network Sql Xml)
 
-install(TARGETS lastfm_fingerprint
+install(TARGETS ${FINGERPRINT_LIB_TARGET_NAME}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/tests/lastfm_add_test.cmake
+++ b/tests/lastfm_add_test.cmake
@@ -9,7 +9,7 @@ macro(lastfm_add_test test_class)
     qt5_use_modules(${LASTFM_TEST_CLASS}Test Core Test Xml Network)
 
     target_link_libraries(${LASTFM_TEST_CLASS}Test
-        lastfm
+        ${LASTFM_LIB_TARGET_NAME}
         ${QT_QTTEST_LIBRARY}
         ${QT_QTCORE_LIBRARY}
     )


### PR DESCRIPTION
This will make Qt5 and Qt4 versions of liblastfm coinstallable on one
system. This is needed as not all applications are ported to Qt5 yet.
