### PR TITLE
Add the ability to change the lastfm host

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -112,7 +112,7 @@ static QUrl baseUrl()
     QUrl url;
 
     if(!lastfm::ws::Server.isEmpty()) {
-        url.setUrl(lastfm::ws::Server);
+        url.setUrl( lastfm::ws::Server );
     }
     else {
         url.setScheme( lastfm::ws::scheme() == lastfm::ws::Https ? "https" : "http" );

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -110,8 +110,15 @@ lastfm::ws::host()
 static QUrl baseUrl()
 {
     QUrl url;
-    url.setScheme( lastfm::ws::scheme() == lastfm::ws::Https ? "https" : "http" );
-    url.setHost( lastfm::ws::host() );
+
+    if(!lastfm::ws::Server.isEmpty()) {
+        url.setUrl(lastfm::ws::Server);
+    }
+    else {
+        url.setScheme( lastfm::ws::scheme() == lastfm::ws::Https ? "https" : "http" );
+        url.setHost( lastfm::ws::host() );
+    }
+
     url.setPath( "/2.0/" );
 
     return url;

--- a/src/ws.h
+++ b/src/ws.h
@@ -61,7 +61,12 @@ namespace lastfm
           * You only need to authenticate once, and that key lasts forever!
           */
         LASTFM_DLLEXPORT extern QString SessionKey;      
-        
+
+        /** Override the host with a compatible scrobbling API server.
+          * The scheme should be included!
+          */
+        LASTFM_DLLEXPORT extern QString Server;
+
         enum Error
         {
             NoError = 1, // because last.fm error numbers start at 2


### PR DESCRIPTION
Add a new attribute to the `ws` class which allow the developper to override the lastfm host with a custom server (with a compatible API obviously).