### PR TITLE
Remove deprecated staging server and fix test for QT5 at Ubuntu 19.10

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -32,7 +32,8 @@
 #include <QMutex>
 #include <QSslSocket>
 
-static lastfm::ws::Scheme theScheme = lastfm::ws::Http;
+static lastfm::ws::Scheme theScheme = lastfm::ws::Https;
+static QString theHost = LASTFM_WS_HOSTNAME;
 static QMap< QThread*, QNetworkAccessManager* > threadNamHash;
 static QSet< QThread* > ourNamSet;
 static QMutex namAccessMutex;
@@ -96,15 +97,13 @@ lastfm::ws::setScheme( lastfm::ws::Scheme scheme )
 QString
 lastfm::ws::host()
 {
-    QStringList const args = QCoreApplication::arguments();
-    if (args.contains( "--debug"))
-        return "ws.staging.audioscrobbler.com";
+    return theHost;
+}
 
-    int const n = args.indexOf( "--host" );
-    if (n != -1 && args.count() > n+1)
-        return args[n+1];
-
-    return LASTFM_WS_HOSTNAME;
+void
+lastfm::ws::setHost( QString host )
+{
+    theHost = host;
 }
 
 static QUrl baseUrl()

--- a/src/ws.h
+++ b/src/ws.h
@@ -44,7 +44,7 @@ namespace lastfm
 
     namespace ws
     {
-        /** both of these are provided when you register at http://last.fm/api */
+        /** both of these are provided when you register at https://www.last.fm/api/ */
         LASTFM_DLLEXPORT extern const char* SharedSecret;
         LASTFM_DLLEXPORT extern const char* ApiKey;
     
@@ -54,8 +54,8 @@ namespace lastfm
 
         /** Some webservices require authentication. See the following
           * documentation:
-          * http://www.last.fm/api/authentication
-          * http://www.last.fm/api/desktopauth
+          * https://www.last.fm/api/authentication
+          * https://www.last.fm/api/desktopauth
           * You have to authenticate and then assign to SessionKey, liblastfm does
           * not do that for you. Also we do not store this. You should store this!
           * You only need to authenticate once, and that key lasts forever!
@@ -122,9 +122,10 @@ namespace lastfm
         LASTFM_DLLEXPORT void setScheme( Scheme scheme );
         LASTFM_DLLEXPORT Scheme scheme();
         
+        LASTFM_DLLEXPORT void setHost( QString host );
         LASTFM_DLLEXPORT QString host();
 
-        /** the map needs a method entry, as per http://last.fm/api */
+        /** the map needs a method entry, as per https://www.last.fm/api/ */
         LASTFM_DLLEXPORT QUrl url( QMap<QString, QString>, bool sessionKey = true);
         LASTFM_DLLEXPORT QNetworkReply* get( QMap<QString, QString> );
         /** generates api sig, includes api key, and posts, don't add the api

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,9 @@
 include(lastfm_add_test.cmake)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/../src)
 
+if(NOT BUILD_WITH_QT4)
+    find_package(Qt5Test REQUIRED)
+endif()
+
 lastfm_add_test(UrlBuilder)
 lastfm_add_test(Track)


### PR DESCRIPTION
Remove "staging" host if "--debug" is set. The host is wrong and setting it via "--debug" clashes with an application own debug